### PR TITLE
Configure Renovate to track Bicep language server releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>sublimelsp/renovate-preset"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Azure Bicep language server version in plugin.py",
+      "managerFilePatterns": ["(^|/)plugin\\.py$"],
+      "matchStrings": [
+        "VERSION = \"(?<currentValue>v[\\d.]+)\""
+      ],
+      "depNameTemplate": "Azure/bicep",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,7 @@
         "VERSION = \"(?<currentValue>v[\\d.]+)\""
       ],
       "depNameTemplate": "Azure/bicep",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Configure Renovate custom regex manager to track Azure/bicep GitHub releases
- Automatically opens PRs to update the `VERSION` string in `plugin.py` when new Bicep language server versions are released

Closes #8

## Test plan
- [ ] Verify Renovate Dependency Dashboard (issue #7) detects `Azure/bicep` as a tracked dependency
- [ ] Confirm next Azure/bicep release triggers an automated PR
