### PR TITLE
Fix Renovate managerFilePatterns pattern matching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     {
       "customType": "regex",
       "description": "Update Azure Bicep language server version in plugin.py",
-      "managerFilePatterns": ["(^|/)plugin\\.py$"],
+      "managerFilePatterns": ["**/plugin.py"],
       "matchStrings": [
         "VERSION = \"(?<currentValue>v[\\d.]+)\""
       ],


### PR DESCRIPTION
## Summary
- Fix `managerFilePatterns` to use a glob pattern (`**/plugin.py`) instead of an undelimited regex
- Without `/` delimiters, Renovate treats `(^|/)plugin\.py$` as a glob, which matches nothing

## Verification
Confirmed with `renovate --dry-run --platform=local` that the glob pattern correctly matches `plugin.py` and extracts `Azure/bicep` at `v0.40.2`.